### PR TITLE
Improve function `pert_scaled` (#1563)

### DIFF
--- a/dpgen/data/gen.py
+++ b/dpgen/data/gen.py
@@ -728,8 +728,7 @@ def make_scale_ABACUS(jdata):
 
 
 def pert_scaled(jdata):
-    if "init_fp_style" not in jdata:
-        jdata["init_fp_style"] = "VASP"
+    ### Extract data from jdata
     out_dir = jdata["out_dir"]
     scale = jdata["scale"]
     pert_box = jdata["pert_box"]
@@ -746,6 +745,7 @@ def pert_scaled(jdata):
     if "from_poscar" in jdata:
         from_poscar = jdata["from_poscar"]
 
+    ### Get the current working directory and the system path
     cwd = os.getcwd()
     path_sp = os.path.join(out_dir, global_dirname_03)
     assert os.path.isdir(path_sp)
@@ -754,35 +754,35 @@ def pert_scaled(jdata):
     sys_pe.sort()
     os.chdir(cwd)
 
-    pert_cmd = os.path.dirname(__file__)
-    pert_cmd = os.path.join(pert_cmd, "tools")
-    pert_cmd = os.path.join(pert_cmd, "create_random_disturb.py")
-    fp_style = "vasp"
-    poscar_name = "POSCAR"
-    if jdata["init_fp_style"] == "ABACUS":
+    ### Construct the perturbation command
+    init_fp_style = jdata.get("init_fp_style", "VASP")
+    if init_fp_style == "VASP":
+        fp_style = "vasp"
+        poscar_name = "POSCAR"
+    elif init_fp_style == "ABACUS":
         fp_style = "abacus"
         poscar_name = "STRU"
-    pert_cmd = (
-        sys.executable
-        + " "
-        + pert_cmd
-        + " -etmax %f -ofmt %s %s %d %f > /dev/null"
-        % (pert_box, fp_style, poscar_name, pert_numb, pert_atom)
+
+    python_exec = os.path.join(
+        os.path.dirname(__file__), "tools", "create_random_disturb.py"
     )
+    pert_cmd = f"{sys.executable} {python_exec} -etmax {pert_box} -ofmt {fp_style} {poscar_name} {pert_numb} {pert_atom} > /dev/null"
+
+    ### Loop over each system and scale
     for ii in sys_pe:
         for jj in scale:
-            path_work = path_sp
-            path_work = os.path.join(path_work, ii)
-            path_work = os.path.join(path_work, f"scale-{jj:.3f}")
+            path_work = os.path.join(path_sp, ii, f"scale-{jj:.3f}")
             assert os.path.isdir(path_work)
             os.chdir(path_work)
             sp.check_call(pert_cmd, shell=True)
+
+            ### Loop over each perturbation
             for kk in range(pert_numb):
                 if fp_style == "vasp":
-                    pos_in = "POSCAR%d.vasp" % (kk + 1)
+                    pos_in = f"POSCAR{kk+1}.vasp"
                 elif fp_style == "abacus":
-                    pos_in = "STRU%d.abacus" % (kk + 1)
-                dir_out = "%06d" % (kk + 1)
+                    pos_in = f"STRU{kk+1}.abacus"
+                dir_out = f"{kk+1:06d}"
                 create_path(dir_out)
                 if fp_style == "vasp":
                     pos_out = os.path.join(dir_out, "POSCAR")
@@ -807,12 +807,14 @@ def pert_scaled(jdata):
                 else:
                     shutil.copy2(pos_in, pos_out)
                 os.remove(pos_in)
+
+            ### Handle special case (unperturbed ?)
             kk = -1
             if fp_style == "vasp":
                 pos_in = "POSCAR"
             elif fp_style == "abacus":
                 pos_in = "STRU"
-            dir_out = "%06d" % (kk + 1)
+            dir_out = f"{kk+1:06d}"
             create_path(dir_out)
             if fp_style == "vasp":
                 pos_out = os.path.join(dir_out, "POSCAR")
@@ -836,6 +838,7 @@ def pert_scaled(jdata):
                         )
             else:
                 shutil.copy2(pos_in, pos_out)
+
             os.chdir(cwd)
 
 


### PR DESCRIPTION
My suggestion:
- Separate VASP and ABACUS into separated functions (and may be separated files). This will helpful to someone who want to implement a new DFT engine and also convenient for maintain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
- Enhanced the `pert_scaled` function to support different initialization styles ("VASP" or "ABACUS").
  
- **Refactor**
- Improved loop logic and file handling for better performance and reliability in perturbation processes.
- Streamlined the `make_vasp_relax` and `make_scale` functions for improved readability and clarity.
- Simplified the construction of perturbation commands in the `pert_scaled` function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---------